### PR TITLE
Implement two loader services

### DIFF
--- a/__tests__/integration/core/template/operations/create-template-operation.int.test.ts
+++ b/__tests__/integration/core/template/operations/create-template-operation.int.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import CreateTemplateOperation from '@core/template/operations/create-template-operation';
-import { beforeEach, describe, expect, vi, it } from 'vitest';
+import { beforeEach, describe, expect, vi, it, afterEach } from 'vitest';
 import container from '@infrastructure/container/di-container';
 import { getSimpleStructureFixture } from '__tests__/fixtures/simple-structure';
 import FastGlob from 'fast-glob';
@@ -8,6 +8,7 @@ import { getFastGlobStreamMock } from '__tests__/helpers';
 import { fs, vol } from 'memfs';
 import { getStoragePath } from '@infrastructure/file-system/paths/get-path';
 import { resolve } from 'node:path';
+import { StubLoaderService } from '@infrastructure/loader/stub-loader-service';
 
 vi.mock('node:fs');
 vi.mock('node:fs/promises');
@@ -26,8 +27,13 @@ vi.mock('@infrastructure/file-system/paths/get-path', () => {
 describe('CreateTemplateOperation Integration Suite', () => {
     let operation: CreateTemplateOperation;
 
+    container.register('LoaderService', {
+        useValue: new StubLoaderService(),
+    });
+
     beforeEach(() => {
         vi.clearAllMocks();
+
         operation = container.resolve<CreateTemplateOperation>('CreateTemplateOperation');
     });
 

--- a/__tests__/integration/core/template/operations/get-template-operation.int.test.ts
+++ b/__tests__/integration/core/template/operations/get-template-operation.int.test.ts
@@ -8,6 +8,7 @@ import { fs, vol } from 'memfs';
 import { getStoragePath } from '@infrastructure/file-system/paths/get-path';
 import { join, resolve } from 'node:path';
 import GetTemplateOperation from '@core/template/operations/get-template-operation';
+import { StubLoaderService } from '@infrastructure/loader/stub-loader-service';
 
 vi.mock('node:fs');
 vi.mock('node:fs/promises');
@@ -25,6 +26,10 @@ vi.mock('@infrastructure/file-system/paths/get-path', () => {
 
 describe('GetTemplateOperation Integration Suite', () => {
     let operation: GetTemplateOperation;
+
+    container.register('LoaderService', {
+        useValue: new StubLoaderService(),
+    });
 
     beforeEach(() => {
         vi.clearAllMocks();

--- a/__tests__/integration/core/template/operations/remove-template-operation.int.test.ts
+++ b/__tests__/integration/core/template/operations/remove-template-operation.int.test.ts
@@ -6,6 +6,7 @@ import { fs, vol } from 'memfs';
 import { getStoragePath } from '@infrastructure/file-system/paths/get-path';
 import RemoveTemplateOperation from '@core/template/operations/remove-template-operation';
 import { join } from 'node:path';
+import { StubLoaderService } from '@infrastructure/loader/stub-loader-service';
 
 vi.mock('node:fs');
 vi.mock('node:fs/promises');
@@ -25,6 +26,10 @@ vi.mock('@infrastructure/file-system/paths/get-path', () => {
 
 describe('RemoveTemplateOperation Integration Suite', () => {
     let operation: RemoveTemplateOperation;
+
+    container.register('LoaderService', {
+        useValue: new StubLoaderService(),
+    });
 
     beforeEach(() => {
         vi.clearAllMocks();

--- a/__tests__/unit/core/file-system/fs-scanner.test.ts
+++ b/__tests__/unit/core/file-system/fs-scanner.test.ts
@@ -5,24 +5,34 @@ import FastGlob from 'fast-glob';
 import { mockGlobEntryStream } from '__tests__/helpers';
 import container from '@infrastructure/container/di-container';
 import { fourGlobEntryObjects } from '__tests__/fixtures/glob-entries';
+import { StubLoaderService } from '@infrastructure/loader/stub-loader-service';
 
 vi.mock('fast-glob');
 
 describe('FileSystemScanner', () => {
-  let scanner: FileSystemScanner;
+    let scanner: FileSystemScanner;
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    scanner = container.resolve<FileSystemScanner>('FileSystemScanner');
-  });
+    container.register('LoaderService', {
+        useValue: new StubLoaderService(),
+    });
 
-  it('returns array of FileSystemEntry objects', async () => {
-    const mockStream = mockGlobEntryStream(fourGlobEntryObjects);
-    vi.mocked(FastGlob.stream).mockReturnValueOnce(mockStream);
+    beforeEach(() => {
+        vi.clearAllMocks();
+        scanner = container.resolve<FileSystemScanner>('FileSystemScanner');
+    });
 
-    const result = await scanner.scan('*');
+    it('returns array of FileSystemEntry objects', async () => {
+        const mockStream = mockGlobEntryStream(fourGlobEntryObjects);
+        vi.mocked(FastGlob.stream).mockReturnValueOnce(mockStream);
 
-    expect(result).toHaveLength(4);
-    expect(result.map(e => e.name)).toEqual(['file1.txt', 'file2.txt', 'subfile.txt', 'subdir']);
-  });
+        const result = await scanner.scan('*');
+
+        expect(result).toHaveLength(4);
+        expect(result.map(e => e.name)).toEqual([
+            'file1.txt',
+            'file2.txt',
+            'subfile.txt',
+            'subdir',
+        ]);
+    });
 });

--- a/src/infrastructure/container/di-container.ts
+++ b/src/infrastructure/container/di-container.ts
@@ -1,19 +1,28 @@
 import { container as tsryngeContainerInstance } from 'tsyringe';
+
 import FileSystemEntryFactory from '@core/file-system/entities/fs-entry-factory.ts';
-import FileSystemScanner from '@core/file-system/services/fs-scanner';
 import TemplateEntryFactory from '@core/template/entities/template-entry-factory.ts';
 import TemplateFactory from '@core/template/entities/template-factory.ts';
-import CreateTemplateOperation from '@core/template/operations/create-template-operation.ts';
+
 import TemplateRepository from '@core/template/repositories/index.ts';
-import CreateTemplateSchema from '@core/template/schemas/create-template-schema.ts';
+
 import TemplateService from '@core/template/services/index.ts';
-import type { DIContainer } from '@shared/types/di.ts';
+import FileSystemScanner from '@core/file-system/services/fs-scanner';
+
+import CreateTemplateOperation from '@core/template/operations/create-template-operation.ts';
 import GetTemplateOperation from '@core/template/operations/get-template-operation';
-import GetTemplateSchema from '@core/template/schemas/get-template-schema';
-import DestinationResolverFactory from '@core/path-resolution/services/destination-resolver-factory';
 import ListTemplateOperation from '@core/template/operations/list-template-operation';
-import RemoveTemplateSchema from '@core/template/schemas/remove-template-schema';
 import RemoveTemplateOperation from '@core/template/operations/remove-template-operation';
+
+import CreateTemplateSchema from '@core/template/schemas/create-template-schema.ts';
+import GetTemplateSchema from '@core/template/schemas/get-template-schema';
+import RemoveTemplateSchema from '@core/template/schemas/remove-template-schema';
+
+import DestinationResolverFactory from '@core/path-resolution/services/destination-resolver-factory';
+
+import { OraLoaderService } from '@infrastructure/loader/ora-loader-service';
+
+import type { DIContainer } from '@shared/types/di.ts';
 
 class TsyringeContainer {
     private _container: DIContainer;
@@ -27,6 +36,7 @@ class TsyringeContainer {
         this.initCoreTemplate();
         this.initCoreFileSystem();
         this.initCorePathResolution();
+        this.initInfrastructureLoader();
     }
 
     initCoreTemplate() {
@@ -88,6 +98,13 @@ class TsyringeContainer {
         // Factories
         this._container.register('DestinationResolverFactory', {
             useClass: DestinationResolverFactory,
+        });
+    }
+
+    initInfrastructureLoader() {
+        // Services
+        this._container.register('LoaderService', {
+            useClass: OraLoaderService,
         });
     }
 

--- a/src/infrastructure/loader/ora-loader-service.ts
+++ b/src/infrastructure/loader/ora-loader-service.ts
@@ -1,0 +1,30 @@
+import ora, { Ora } from 'ora';
+import { injectable } from 'tsyringe';
+import { LoaderService } from '@shared/interfaces/loader-service';
+
+@injectable()
+export class OraLoaderService implements LoaderService {
+    private spinnerInstance: Ora;
+    constructor() {
+        this.spinnerInstance = ora();
+    }
+
+    start(text: string) {
+        this.spinnerInstance.start(text);
+    }
+
+    succeed(text: string) {
+        this.spinnerInstance.succeed(text);
+    }
+
+    fail(text: string) {
+        this.spinnerInstance.fail(text);
+    }
+
+    update(props: { text?: string; suffixText?: string }): void {
+        const { text, suffixText } = props;
+
+        if (text) this.spinnerInstance.text = text;
+        if (suffixText) this.spinnerInstance.suffixText = suffixText;
+    }
+}

--- a/src/infrastructure/loader/stub-loader-service.ts
+++ b/src/infrastructure/loader/stub-loader-service.ts
@@ -1,0 +1,10 @@
+import { injectable } from 'tsyringe';
+import { LoaderService } from '@shared/interfaces/loader-service';
+
+@injectable()
+export class StubLoaderService implements LoaderService {
+    start(_text: string): void {}
+    succeed(_text: string): void {}
+    fail(_text: string): void {}
+    update(_props: { text?: string; suffixText?: string }): void {}
+}

--- a/src/shared/interfaces/loader-service.ts
+++ b/src/shared/interfaces/loader-service.ts
@@ -1,0 +1,6 @@
+export interface LoaderService {
+    start(text?: string): void;
+    succeed(text?: string): void;
+    fail(text?: string): void;
+    update(props: { text?: string; suffixText?: string }): void;
+}


### PR DESCRIPTION
This PR adds a `LoaderService` interface  and integrates two of its implementations:

- `OraLoaderService` - a real implementation and uses the npm package 'ora'
- `StubLoaderService` - a stub that can be used in tests, as well as disable `LoaderService` if necessary.